### PR TITLE
Let mysql convert epoch to timestamp string value

### DIFF
--- a/record.php
+++ b/record.php
@@ -64,15 +64,10 @@ if ($data['_type'] == 'location') {
     }
     $user = $_SERVER['PHP_AUTH_USER'];
 
-    if ($epoch) {
-        $dt = new DateTime("@$epoch");  // convert UNIX timestamp to PHP DateTime
-        $timestamp = $dt->format('Y-m-d H:i:s'); // output = 2017-01-01 00:00:00
-    }
-
     $sql = "INSERT INTO ".$_config['sql_prefix']."locations
     (dt, accuracy, altitude, battery_level, heading, description, event, latitude, longitude, radius, trig, tracker_id,
      epoch, vertical_accuracy, velocity, pressure, connection, user)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+      VALUES (FROM_UNIXTIME(?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
     if ($stmt = $mysqli->prepare($sql)) {
         # bind parameters (s = string, i = integer, d = double,  b = blob)
         $stmt->bind_param(


### PR DESCRIPTION
Mysql expects timestamp string at system timezone, but record.php converts the epoch value to a timestamp string according to UTC. Mysql's FROM_UNIXTIME converts using the system timezone. So let's use Mysql's FROM_UNIXTIME.